### PR TITLE
adding ETH Zurich institute page.

### DIFF
--- a/pages/institutions/eth.md
+++ b/pages/institutions/eth.md
@@ -1,0 +1,31 @@
+---
+title: ETH Zurich
+permalink: /institutions/eth/
+pagetype: institution
+---
+
+# ETH Zurich 
+
+  The ETH board has formed a task force to identify research, innovation, and
+advising opportunities to help fight against SARS-CoV-2. The board is 
+described [on the board website.](https://www.ethrat.ch/en/eth-domain-covid-19-task-force)
+
+  Their listed high priority tasks are:
+  * Increase capacity for Virus tests
+
+  * Increase capacity for Serological Tests
+
+  * Exchange information with clinics
+
+  * Create a platform for expertise, material, equipment and personel
+
+  * Create a platform to exchange data for epidimeological modelling
+    
+  * Develop approaches for making and reusing masks
+
+  * Contribute to communication campaigns
+
+Their website also links to [a 
+platform](https://ethz.ch/services/en/news-and-events/solidarity/akademische-ressourcen.html) 
+ for members of Swiss academic institutions to provide academic resources to 
+the healthcare system. 


### PR DESCRIPTION
A simple institute page to start for ETH Zurich.